### PR TITLE
[WIP] Add table for watched addresses in eth schema

### DIFF
--- a/db/migrations/00017_create_watched_addresses_table.sql
+++ b/db/migrations/00017_create_watched_addresses_table.sql
@@ -1,6 +1,7 @@
 -- +goose Up
 CREATE TABLE eth.watched_addresses (
     address                 VARCHAR(66) PRIMARY KEY,
+    kind                    INTEGER NULL NULL,
     created_at              BIGINT NOT NULL,
     watched_at              BIGINT NOT NULL,
     last_filled_at          BIGINT NOT NULL DEFAULT 0

--- a/db/migrations/00017_create_watched_addresses_table.sql
+++ b/db/migrations/00017_create_watched_addresses_table.sql
@@ -1,7 +1,9 @@
 -- +goose Up
 CREATE TABLE eth.watched_addresses (
-    address               VARCHAR(66) PRIMARY KEY,
-    added_at              BIGINT NOT NULL
+    address                 VARCHAR(66) PRIMARY KEY,
+    created_at              BIGINT NOT NULL,
+    watched_at              BIGINT NOT NULL,
+    last_filled_at          BIGINT NOT NULL DEFAULT 0
 );
 
 -- +goose Down

--- a/db/migrations/00017_create_watched_addresses_table.sql
+++ b/db/migrations/00017_create_watched_addresses_table.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+CREATE TABLE eth.watched_addresses (
+    address               VARCHAR(66) PRIMARY KEY,
+    added_at              BIGINT NOT NULL
+);
+
+-- +goose Down
+DROP TABLE eth.watched_addresses;

--- a/schema.sql
+++ b/schema.sql
@@ -558,6 +558,7 @@ ALTER SEQUENCE eth.uncle_cids_id_seq OWNED BY eth.uncle_cids.id;
 
 CREATE TABLE eth.watched_addresses (
     address character varying(66) NOT NULL,
+    kind integer,
     created_at bigint NOT NULL,
     watched_at bigint NOT NULL,
     last_filled_at bigint DEFAULT 0 NOT NULL

--- a/schema.sql
+++ b/schema.sql
@@ -553,6 +553,16 @@ ALTER SEQUENCE eth.uncle_cids_id_seq OWNED BY eth.uncle_cids.id;
 
 
 --
+-- Name: watched_addresses; Type: TABLE; Schema: eth; Owner: -
+--
+
+CREATE TABLE eth.watched_addresses (
+    address character varying(66) NOT NULL,
+    added_at bigint NOT NULL
+);
+
+
+--
 -- Name: blocks; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -861,6 +871,14 @@ ALTER TABLE ONLY eth.uncle_cids
 
 ALTER TABLE ONLY eth.uncle_cids
     ADD CONSTRAINT uncle_cids_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: watched_addresses watched_addresses_pkey; Type: CONSTRAINT; Schema: eth; Owner: -
+--
+
+ALTER TABLE ONLY eth.watched_addresses
+    ADD CONSTRAINT watched_addresses_pkey PRIMARY KEY (address);
 
 
 --

--- a/schema.sql
+++ b/schema.sql
@@ -558,7 +558,9 @@ ALTER SEQUENCE eth.uncle_cids_id_seq OWNED BY eth.uncle_cids.id;
 
 CREATE TABLE eth.watched_addresses (
     address character varying(66) NOT NULL,
-    added_at bigint NOT NULL
+    created_at bigint NOT NULL,
+    watched_at bigint NOT NULL,
+    last_filled_at bigint DEFAULT 0 NOT NULL
 );
 
 


### PR DESCRIPTION
Implemented:

- Migration for creating a table in `eth` schema that stores watched addresses used in geth while direct indexing